### PR TITLE
merlin: `HashChainTranscript` fully mirrors `Transcript` API

### DIFF
--- a/src/hash_chain_transcript.rs
+++ b/src/hash_chain_transcript.rs
@@ -19,6 +19,29 @@ pub fn keccak256(input: &[u8], dest: &mut [u8]) {
     hasher.finalize(dest);
 }
 
+/// Pad a label to 32 bytes in a manner consistent with Cairo.
+/// Panics if the label is longer than 32 bytes.
+pub fn pad_label(label: &[u8]) -> [u8; 32] {
+    // In Cairo, the label is stored as a big-endian u256, but is read
+    // into the Keccak hash function in little-endian (i.e., reverse) byte order.
+    // This function replicates that by left-padding the label w/ zeros
+    // (preserving its value as a big-endian u256), then reversing the bytes.
+    assert!(
+        label.len() <= 32,
+        "Label must be less than or equal to 32 bytes",
+    );
+    let mut padded_label = [0u8; 32];
+    padded_label[32 - label.len()..].copy_from_slice(label);
+    padded_label
+        .iter()
+        .rev()
+        .cloned()
+        .collect::<Vec<u8>>()
+        .try_into()
+        .unwrap()
+}
+
+#[derive(Clone)]
 pub struct HashChainTranscript {
     state: [u8; 32],
 }
@@ -28,7 +51,7 @@ impl HashChainTranscript {
     pub fn new(label: &'static [u8]) -> Self {
         let mut state = [0u8; 32];
 
-        keccak256(&HashChainTranscript::pad_label(label), &mut state);
+        keccak256(&pad_label(label), &mut state);
         HashChainTranscript { state }
     }
 
@@ -36,7 +59,7 @@ impl HashChainTranscript {
     pub fn append_message(&mut self, label: &'static [u8], message: &[u8]) {
         let data: Vec<u8> = message
             .iter()
-            .chain(HashChainTranscript::pad_label(label).iter())
+            .chain(pad_label(label).iter())
             .chain(self.state.iter())
             .cloned()
             .collect();
@@ -51,7 +74,7 @@ impl HashChainTranscript {
 
     /// Squeeze 32 challenge bytes out of the transcript state
     pub fn challenge_bytes(&mut self, label: &'static [u8], dest: &mut [u8]) {
-        let data: Vec<u8> = HashChainTranscript::pad_label(label)
+        let data: Vec<u8> = pad_label(label)
             .iter()
             .chain(self.state.iter())
             .cloned()
@@ -64,27 +87,79 @@ impl HashChainTranscript {
         dest.copy_from_slice(&output);
     }
 
-    /// Pad a label to 32 bytes in a manner consistent with Cairo.
-    /// Panics if the label is longer than 32 bytes.
-    pub fn pad_label(label: &'static [u8]) -> [u8; 32] {
-        // In Cairo, the label is stored as a big-endian u256, but is read
-        // into the Keccak hash function in little-endian (i.e., reverse) byte order.
-        // This function replicates that by left-padding the label w/ zeros
-        // (preserving its value as a big-endian u256), then reversing the bytes.
-        assert!(
-            label.len() <= 32,
-            "Label must be less than or equal to 32 bytes",
-        );
-        let mut padded_label = [0u8; 32];
-        padded_label[32 - label.len()..].copy_from_slice(label);
-        padded_label
-            .iter()
-            .rev()
-            .cloned()
-            .collect::<Vec<u8>>()
-            .try_into()
-            .unwrap()
+    /// Fork the current [`HashChainTranscript`] to construct an RNG whose output is bound
+    /// to the current transcript state as well as prover's secrets.
+    pub fn build_rng(&self) -> HashChainTranscriptRngBuilder {
+        HashChainTranscriptRngBuilder {
+            transcript: self.clone(),
+        }
     }
 }
 
-// TODO: Maybe impl `TranscriptRngBuilder` for `HashChainTranscript`?
+pub struct HashChainTranscriptRngBuilder {
+    transcript: HashChainTranscript,
+}
+
+impl HashChainTranscriptRngBuilder {
+    /// Rekey the transcript using the provided witness data.
+    ///
+    /// The `label` parameter is metadata about `witness`.
+    pub fn rekey_with_witness_bytes(
+        mut self,
+        label: &'static [u8],
+        witness: &[u8],
+    ) -> HashChainTranscriptRngBuilder {
+        self.transcript.append_message(label, witness);
+        self
+    }
+
+    /// Use the supplied external `rng` to rekey the transcript, so
+    /// that the finalized [`TranscriptRng`] is a PRF bound to
+    /// randomness from the external RNG, as well as all other
+    /// transcript data.
+    pub fn finalize<R>(mut self, rng: &mut R) -> HashChainTranscriptRng
+    where
+        R: rand_core::RngCore + rand_core::CryptoRng,
+    {
+        let random_bytes = {
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes
+        };
+
+        self.transcript.append_message(b"rng", &random_bytes);
+
+        HashChainTranscriptRng {
+            transcript: self.transcript,
+        }
+    }
+}
+
+pub struct HashChainTranscriptRng {
+    transcript: HashChainTranscript,
+}
+
+impl rand_core::RngCore for HashChainTranscriptRng {
+    fn next_u32(&mut self) -> u32 {
+        let mut bytes = [0_u8; 32];
+        self.transcript.challenge_bytes(b"next_u32", &mut bytes);
+        u32::from_le_bytes(bytes[0..4].try_into().unwrap())
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut bytes = [0_u8; 32];
+        self.transcript.challenge_bytes(b"next_u64", &mut bytes);
+        u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        rand_core::impls::fill_bytes_via_next(self, dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.fill_bytes(dest);
+        Ok(())
+    }
+}
+
+impl rand_core::CryptoRng for HashChainTranscriptRng {}

--- a/src/hash_chain_transcript.rs
+++ b/src/hash_chain_transcript.rs
@@ -13,7 +13,7 @@ fn encode_u64_as_u256_le(x: u64) -> [u8; 32] {
 }
 
 /// Compute the Keccak256 hash of `input` and write it to `dest`
-fn keccak256(input: &[u8], dest: &mut [u8]) {
+pub fn keccak256(input: &[u8], dest: &mut [u8]) {
     let mut hasher = Keccak::v256();
     hasher.update(input.as_ref());
     hasher.finalize(dest);
@@ -66,7 +66,7 @@ impl HashChainTranscript {
 
     /// Pad a label to 32 bytes in a manner consistent with Cairo.
     /// Panics if the label is longer than 32 bytes.
-    fn pad_label(label: &'static [u8]) -> [u8; 32] {
+    pub fn pad_label(label: &'static [u8]) -> [u8; 32] {
         // In Cairo, the label is stored as a big-endian u256, but is read
         // into the Keccak hash function in little-endian (i.e., reverse) byte order.
         // This function replicates that by left-padding the label w/ zeros
@@ -86,3 +86,5 @@ impl HashChainTranscript {
             .unwrap()
     }
 }
+
+// TODO: Maybe impl `TranscriptRngBuilder` for `HashChainTranscript`?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ pub use crate::transcript::Transcript;
 pub use crate::transcript::TranscriptRng;
 pub use crate::transcript::TranscriptRngBuilder;
 
-pub use crate::hash_chain_transcript::HashChainTranscript;
+pub use crate::hash_chain_transcript::{keccak256, HashChainTranscript};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ pub use crate::transcript::Transcript;
 pub use crate::transcript::TranscriptRng;
 pub use crate::transcript::TranscriptRngBuilder;
 
-pub use crate::hash_chain_transcript::{keccak256, HashChainTranscript};
+pub use crate::hash_chain_transcript::{keccak256, pad_label, HashChainTranscript};


### PR DESCRIPTION
This PR primarily implements `TranscriptRng` for `HashChainTranscript`, so that it can be used as a drop-in w/ minimal code changes in the `mpc-bulletproof` repo